### PR TITLE
WIP: fix broken memory allocator API usage and bad BAR state after resets

### DIFF
--- a/etc/fpgas.json
+++ b/etc/fpgas.json
@@ -3,7 +3,7 @@
       "vc707": {
         "id": "10ee:7021",
         "slot": "0000:88:00.0",
-        "do_reset": true,
+        "do_reset": false,
         "ips": "etc/vc707-xbar-pcie/vc707-xbar-pcie.json",
         "polling": false
       }

--- a/include/villas/fpga/card.hpp
+++ b/include/villas/fpga/card.hpp
@@ -89,11 +89,11 @@ public:
 	lookupIp(const ip::IpIdentifier &id) const;
 
 	bool
-	mapMemoryBlock(const MemoryBlock &block);
+	mapMemoryBlock(std::shared_ptr<MemoryBlock> block);
 
 private:
 	// Cache a set of already mapped memory blocks
-	std::set<MemoryManager::AddressSpaceId> memoryBlocksMapped;
+	std::map<MemoryManager::AddressSpaceId, std::shared_ptr<MemoryBlock>> memoryBlocksMapped;
 
 public:	// TODO: make this private
 	std::list<std::shared_ptr<ip::Core>> ips;				// IPs located on this FPGA card

--- a/include/villas/fpga/ips/dma.hpp
+++ b/include/villas/fpga/ips/dma.hpp
@@ -63,8 +63,8 @@ public:
 
 	bool memcpy(const MemoryBlock &src, const MemoryBlock &dst, size_t len);
 
-	void makeAccesibleFromVA(const MemoryBlock &mem);
-	bool makeInaccesibleFromVA(const MemoryBlock &mem);
+	void makeAccesibleFromVA(std::shared_ptr<MemoryBlock> mem);
+	bool makeInaccesibleFromVA(std::shared_ptr<MemoryBlock> mem);
 
 	inline
 	bool hasScatterGather() const
@@ -147,8 +147,8 @@ private:
 	// Depending on alignment, the actual number of BDs usable can be smaller
 	static constexpr size_t requestedRingBdSize = 2048;
 	uint32_t actualRingBdSize = XAxiDma_BdRingCntCalc(XAXIDMA_BD_MINIMUM_ALIGNMENT, requestedRingBdSize);
-	MemoryBlock::UniquePtr sgRingTx;
-	MemoryBlock::UniquePtr sgRingRx;
+	MemoryBlock::Ptr sgRingTx;
+	MemoryBlock::Ptr sgRingRx;
 };
 
 class DmaFactory : public NodeFactory {

--- a/include/villas/fpga/ips/dma.hpp
+++ b/include/villas/fpga/ips/dma.hpp
@@ -147,8 +147,8 @@ private:
 	// Depending on alignment, the actual number of BDs usable can be smaller
 	static constexpr size_t requestedRingBdSize = 2048;
 	uint32_t actualRingBdSize = XAxiDma_BdRingCntCalc(XAXIDMA_BD_MINIMUM_ALIGNMENT, requestedRingBdSize);
-	MemoryBlock::Ptr sgRingTx;
-	MemoryBlock::Ptr sgRingRx;
+	std::shared_ptr<villas::MemoryBlock> sgRingTx;
+	std::shared_ptr<villas::MemoryBlock> sgRingRx;
 };
 
 class DmaFactory : public NodeFactory {

--- a/lib/ips/dma.cpp
+++ b/lib/ips/dma.cpp
@@ -191,16 +191,13 @@ bool Dma::reset()
 	int timeout = 500;
 
 	while (timeout > 0) {
-		if (XAxiDma_ResetIsDone(&xDma))
+		if (XAxiDma_ResetIsDone(&xDma)) {
+			logger->info("DMA has been reset.");
 			return true;
-
+		}
 		timeout--;
 	}
-	if (timeout == 0) {
-		logger->error("DMA reset timed out");
-	} else {
-		logger->info("DMA has been reset.");
-	}
+	logger->error("DMA reset timed out");
 
 	return false;
 }

--- a/src/villas-fpga-cat.cpp
+++ b/src/villas-fpga-cat.cpp
@@ -76,7 +76,7 @@ int main(int argc, char* argv[])
 		// 	 still accesses the allocated memory. This order ensures that the allocator
 		//       is destroyed AFTER the card.
 		auto &alloc = villas::HostRam::getAllocator();
-		const villas::MemoryBlock::Ptr block[] = {
+		const std::shared_ptr<villas::MemoryBlock> block[] = {
 			std::move(alloc.allocateBlock(sizeof(int32_t)*0x200)),
 			std::move(alloc.allocateBlock(sizeof(int32_t)*0x200)),
 		};

--- a/src/villas-fpga-pipe.cpp
+++ b/src/villas-fpga-pipe.cpp
@@ -104,8 +104,8 @@ int main(int argc, char* argv[])
 		dma->connectLoopback();
 #endif
 		auto &alloc = villas::HostRam::getAllocator();
-		auto mem = alloc.allocate<int32_t>(0x100);
-		auto block = mem.getMemoryBlock();
+		const villas::MemoryBlock::Ptr block = std::move(alloc.allocateBlock(sizeof(int32_t)*0x100));
+		int32_t* mem = reinterpret_cast<int32_t*>(block->getOffset());
 
 		dma->makeAccesibleFromVA(block);
 
@@ -114,7 +114,7 @@ int main(int argc, char* argv[])
 
 		while (true) {
 			// Setup read transfer
-			dma->read(block, block.getSize());
+			dma->read(*block, block->getSize());
 
 			// Read values from stdin
 			std::string line;
@@ -130,7 +130,7 @@ int main(int argc, char* argv[])
 			}
 
 			// Initiate write transfer
-			bool state = dma->write(block, i * sizeof(int32_t));
+			bool state = dma->write(*block, i * sizeof(int32_t));
 			if (!state)
 				logger->error("Failed to write to device");
 

--- a/src/villas-fpga-pipe.cpp
+++ b/src/villas-fpga-pipe.cpp
@@ -104,7 +104,7 @@ int main(int argc, char* argv[])
 		dma->connectLoopback();
 #endif
 		auto &alloc = villas::HostRam::getAllocator();
-		const villas::MemoryBlock::Ptr block = std::move(alloc.allocateBlock(sizeof(int32_t)*0x100));
+		const std::shared_ptr<villas::MemoryBlock> block = std::move(alloc.allocateBlock(sizeof(int32_t)*0x100));
 		int32_t* mem = reinterpret_cast<int32_t*>(block->getOffset());
 
 		dma->makeAccesibleFromVA(block);

--- a/tests/unit/dma.cpp
+++ b/tests/unit/dma.cpp
@@ -82,8 +82,9 @@ Test(fpga, dma, .description = "DMA")
 		auto dst = HostRam::getAllocator().allocate<char>(len);
 #endif
 		// Make sure memory is accessible for DMA
-		dma->makeAccesibleFromVA(src.getMemoryBlock());
-		dma->makeAccesibleFromVA(dst.getMemoryBlock());
+		//TODO: BROKEN API
+		//dma->makeAccesibleFromVA(src.getMemoryBlock());
+		//dma->makeAccesibleFromVA(dst.getMemoryBlock());
 
 		// Get new random data
 		const size_t lenRandom = utils::readRandom(&src, len);

--- a/tests/unit/dma.cpp
+++ b/tests/unit/dma.cpp
@@ -83,15 +83,15 @@ Test(fpga, dma, .description = "DMA")
 #endif
 		// Make sure memory is accessible for DMA
 		//TODO: BROKEN API
-		//dma->makeAccesibleFromVA(src.getMemoryBlock());
-		//dma->makeAccesibleFromVA(dst.getMemoryBlock());
+		dma->makeAccesibleFromVA(src.getMemoryBlock());
+		dma->makeAccesibleFromVA(dst.getMemoryBlock());
 
 		// Get new random data
 		const size_t lenRandom = utils::readRandom(&src, len);
 		cr_assert(len == lenRandom, "Failed to get random data");
 
 		// Start transfer
-		cr_assert(dma->memcpy(src.getMemoryBlock(), dst.getMemoryBlock(), len),
+		cr_assert(dma->memcpy(*src.getMemoryBlock(), *dst.getMemoryBlock(), len),
 		          "DMA ping pong failed");
 
 		// Compare data

--- a/tests/unit/rtds.cpp
+++ b/tests/unit/rtds.cpp
@@ -91,7 +91,7 @@ Test(fpga, rtds, .description = "RTDS")
 				logger->info("RTT iteration {}", i);
 
 //				logger->info("Prepare read");
-				cr_assert(dma->read(mem.getMemoryBlock(), mem.getMemoryBlock().getSize()),
+				cr_assert(dma->read(*mem.getMemoryBlock(), mem.getMemoryBlock()->getSize()),
 				          "Failed to initiate DMA read");
 
 //				logger->info("Wait read");
@@ -101,7 +101,7 @@ Test(fpga, rtds, .description = "RTDS")
 
 //				logger->info("Bytes received: {}", bytesRead);
 //				logger->info("Prepare write");
-				cr_assert(dma->write(mem.getMemoryBlock(), bytesRead),
+				cr_assert(dma->write(*mem.getMemoryBlock(), bytesRead),
 				          "Failed to initiate DMA write");
 
 //				logger->info("Wait write");


### PR DESCRIPTION
The memory allocator API seems to be broken. Memory gets destroyed at the wrong points in time leading to weird internal states, e.g., of the memory graph. The reason is very inconsistent use of unique_ptr and raw ptrs. I converted some pointers to shared_ptr, but memory.cpp needs a lot more rework.
My changes fix errors when destroying the Dma objects because the vertexes got removed from the memory graph before the memory was unmapped.

Further, this fixes that successive launches required rescanning of the PCIe Bus. After resetting the vfio device the programmed BARs in the config space were reset to 0. We now reprogram the BARs if the config space value is different from what the kernel thinks the BAR shoudl be. 

Signed-off-by: Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>