### PR TITLE
Remove duplicate inherited members and functions in PcieCard class

### DIFF
--- a/include/villas/fpga/card.hpp
+++ b/include/villas/fpga/card.hpp
@@ -21,6 +21,8 @@ class Card
 {
 public:
         bool polling;
+
+        std::shared_ptr<kernel::vfio::Container> vfioContainer;
         std::shared_ptr<kernel::vfio::Device> vfioDevice;
 
         // Slave address space ID to access the PCIe address space from the
@@ -32,13 +34,12 @@ public:
         // card.
         MemoryManager::AddressSpaceId addrSpaceIdHostToDevice;
 
-        std::list<std::shared_ptr<ip::Core> > ips;
+        std::list<std::shared_ptr<ip::Core>> ips;
 
         virtual ~Card();
 
-        bool mapMemoryBlock(const std::shared_ptr<MemoryBlock> block);
-        bool unmapMemoryBlock(const MemoryBlock &block);
-	std::shared_ptr<kernel::vfio::Container> vfioContainer;
+        virtual bool mapMemoryBlock(const std::shared_ptr<MemoryBlock> block);
+        virtual bool unmapMemoryBlock(const MemoryBlock &block);
 
         std::shared_ptr<ip::Core> lookupIp(const std::string &name) const;
         std::shared_ptr<ip::Core> lookupIp(const Vlnv &vlnv) const;

--- a/include/villas/fpga/pcie_card.hpp
+++ b/include/villas/fpga/pcie_card.hpp
@@ -59,18 +59,6 @@ public:
 	void dump()
 	{ }
 
-	std::shared_ptr<ip::Core>
-	lookupIp(const std::string &name) const;
-
-	std::shared_ptr<ip::Core>
-	lookupIp(const Vlnv &vlnv) const;
-
-	std::shared_ptr<ip::Core>
-	lookupIp(const ip::IpIdentifier &id) const;
-
-	bool mapMemoryBlock(const MemoryBlock &block);
-	bool unmapMemoryBlock(const MemoryBlock &block);
-
 public:	// TODO: make this private
 	bool doReset;					// Reset VILLASfpga during startup?
 	int affinity;					// Affinity for MSI interrupts
@@ -78,13 +66,6 @@ public:	// TODO: make this private
 	std::string name;				// The name of the FPGA card
 
 	std::shared_ptr<kernel::pci::Device> pdev;	// PCI device handle
-
-	// Slave address space ID to access the PCIe address space from the FPGA
-	MemoryManager::AddressSpaceId addrSpaceIdDeviceToHost;
-
-	// Address space identifier of the master address space of this FPGA card.
-	// This will be used for address resolution of all IPs on this card.
-	MemoryManager::AddressSpaceId addrSpaceIdHostToDevice;
 
 protected:
 	Logger

--- a/lib/pcie_card.cpp
+++ b/lib/pcie_card.cpp
@@ -155,39 +155,6 @@ PCIeCard::~PCIeCard()
 
 }
 
-std::shared_ptr<ip::Core> PCIeCard::lookupIp(const std::string &name) const
-{
-	for (auto &ip : ips) {
-		if (*ip == name) {
-			return ip;
-		}
-	}
-
-	return nullptr;
-}
-
-std::shared_ptr<ip::Core> PCIeCard::lookupIp(const Vlnv &vlnv) const
-{
-	for (auto &ip : ips) {
-		if (*ip == vlnv) {
-			return ip;
-		}
-	}
-
-	return nullptr;
-}
-
-std::shared_ptr<ip::Core> PCIeCard::lookupIp(const ip::IpIdentifier &id) const
-{
-	for (auto &ip : ips) {
-		if (*ip == id) {
-			return ip;
-		}
-	}
-
-	return nullptr;
-}
-
 bool PCIeCard::init()
 {
 	logger = getLogger();


### PR DESCRIPTION
Cleanup by removing duplicated members. We should enable warnings for this in the pipeline.