### PR TITLE
Make REUSE copyright notice the same as in other VILLASframework projects and fix comments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 # Project-wide dockerignore file
 #
-# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
 # SPDX-License-Identifier: Apache-2.0
 
 *

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 # EditorConfig is awesome: http://EditorConfig.org
 #
-# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
 # SPDX-License-Identifier: Apache-2.0
 
 # top-most EditorConfig file

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Project-wide gitignore file
 #
-# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
 # SPDX-License-Identifier: Apache-2.0
 
 build/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 # GitLab CI configuration
 #
-# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
 # SPDX-License-Identifier: Apache-2.0
 
 variables:
@@ -10,24 +10,11 @@ variables:
   DOCKER_IMAGE_DEV: villas/fpga-dev
 
 stages:
-- lint
 - prepare
 - build
 - test
 
-# Stage: lint
-##############################################################################
-
-reuse:
-  stage: lint
-  image:
-    name: fsfe/reuse:latest
-    entrypoint: [""]
-  script:
-  - reuse lint
-
 # Stage: prepare
-##############################################################################
 
 # Build docker image which is used to build & test VILLASnode
 docker-dev:
@@ -38,7 +25,6 @@ docker-dev:
   - docker
 
 # Stage: build
-##############################################################################
 
 build:source:
   stage: build
@@ -54,7 +40,6 @@ build:source:
   - docker
 
 # Stage: test
-##############################################################################
 
 test:unit:
   stage: test
@@ -102,3 +87,11 @@ test:cppcheck:
     paths:
     - cppcheck.log
     expose_as: cppcheck
+
+test:reuse:
+  stage: test
+  image:
+    name: fsfe/reuse:latest
+    entrypoint: [""]
+  script:
+  - reuse lint

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 # Git submodule list
 #
-# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
 # SPDX-License-Identifier: Apache-2.0
 
 [submodule "common"]

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -4,5 +4,5 @@ Upstream-Contact: Steffen Vogel <post@steffenvogel.de>
 Source: https://fein-aachen.org/en/projects/villas-fpga/
 
 Files: .vscode/* doc/pictures/* etc/**.json
-Copyright: 2018-2022, Institute for Automation of Complex Power Systems, EONERC
+Copyright: 2018-2023, Institute for Automation of Complex Power Systems, RWTH Aachen University
 License: Apache-2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+<!--
+SPDX-FileCopyrightText: 2023 OPAL-RT Germany GmbH
+SPDX-License-Identifier: Apache-2.0
+-->
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
@@ -23,8 +28,3 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Sourcecode import from VILLASnode project:  
   http://git.rwth-aachen.de/VILLASframework/VILLASnode
-
-## License
-
-SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
-SPDX-License-Identifier: Apache-2.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,8 @@
 ## CMakeLists.txt
 #
 # Author: Daniel Krebs <github@daniel-krebs.net>
-# SPDX-FileCopyrightText: 2018 Institute for Automation of Complex Power Systems, EONERC
+# SPDX-FileCopyrightText: 2018 Institute for Automation of Complex Power Systems, RWTH Aachen University
 # SPDX-License-Identifier: Apache-2.0
-##############################################################################
  
 cmake_minimum_required(VERSION 3.5)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,8 @@
 #   make docker
 #
 # Author: Steffen Vogel <post@steffenvogel.de>
-# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
 # SPDX-License-Identifier: Apache-2.0
-###################################################################################
 
 FROM rockylinux:9
 

--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Institute for Automation of Complex Power Systems, EONERC.
+Copyright (c) 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/LICENSES/WTFPL.txt
+++ b/LICENSES/WTFPL.txt
@@ -1,7 +1,7 @@
 DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
 Version 2, December 2004
 
-Copyright (C) 2017 Institute for Automation of Complex Power Systems, EONERC
+Copyright (C) 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
 
 Everyone is permitted to copy and distribute verbatim or modified copies of this license document, and changing it is allowed as long as the name is changed.
 

--- a/README.md
+++ b/README.md
@@ -9,20 +9,14 @@ VILLASfpga supports Xilinx FPGAs connected to a Linux system via PCI-Express or 
 
 User documentation is available here: <https://villas.fein-aachen.org/doc/fpga.html>
 
-## Copyright
-
-- 2022 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
-- 2018-2022 Steffen Vogel <post@steffenvogel.de>
-- 2018 Daniel Krebs <dkrebs@eonerc.rwth-aachen.de>
-
 ## License
 
 This project is released under the terms of the [Apache 2.0](LICENSE) license:
 
-SPDX-FileCopyrightText: 2022-2023 Niklas Eiling
-SPDX-FileCopyrightText: 2018-2023 Steffen Vogel
-SPDX-FileCopyrightText: 2018 Daniel Krebs
-SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2022-2023 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
+- SPDX-FileCopyrightText: 2018-2023 Steffen Vogel <post@steffenvogel.de>
+- SPDX-FileCopyrightText: 2018 Daniel Krebs <dkrebs@eonerc.rwth-aachen.de>
+- SPDX-License-Identifier: Apache-2.0
 
 We kindly ask all academic publications employing components of VILLASframework to cite one of the following papers:
 

--- a/cmake/FindCriterion.cmake
+++ b/cmake/FindCriterion.cmake
@@ -5,9 +5,8 @@
 #  CRITERION_INCLUDE_DIRS - The Criterion include directories
 #  CRITERION_LIBRARIES - The libraries needed to use Criterion
 #
-# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
 # SPDX-License-Identifier: WTFPL
-##############################################################################
 
 find_package(PkgConfig)
 
@@ -20,7 +19,8 @@ set(CRITERION_LIBRARIES ${CRITERION_LIBRARY})
 set(CRITERION_INCLUDE_DIRS ${CRITERION_INCLUDE_DIR})
 
 include(FindPackageHandleStandardArgs)
-# handle the QUIET and REQUIRED arguments and set CRITERION_FOUND to TRUE
+
+# Handle the QUIET and REQUIRED arguments and set CRITERION_FOUND to TRUE
 # if all listed variables are TRUE
 find_package_handle_standard_args(Criterion DEFAULT_MSG
                                   CRITERION_LIBRARY CRITERION_INCLUDE_DIR)

--- a/gpu/CMakeLists.txt
+++ b/gpu/CMakeLists.txt
@@ -1,9 +1,8 @@
 ## CMakeLists.txt
 #
 # Author: Daniel Krebs <github@daniel-krebs.net>
-# SPDX-FileCopyrightText: 2018 Institute for Automation of Complex Power Systems, EONERC
+# SPDX-FileCopyrightText: 2018 Institute for Automation of Complex Power Systems, RWTH Aachen University
 # SPDX-License-Identifier: Apache-2.0
-##############################################################################
 
 cmake_minimum_required(VERSION 3.8)
 

--- a/gpu/include/villas/gpu.hpp
+++ b/gpu/include/villas/gpu.hpp
@@ -1,7 +1,7 @@
 /* GPU managment.
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
- * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/gpu/include/villas/gpu.hpp
+++ b/gpu/include/villas/gpu.hpp
@@ -1,9 +1,9 @@
-/** GPU managment.
+/* GPU managment.
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -96,5 +96,5 @@ private:
 	Logger logger;
 };
 
-} /* namespace villas */
-} /* namespace gpu */
+} // namespace villas
+} // namespace gpu

--- a/gpu/kernels.hpp
+++ b/gpu/kernels.hpp
@@ -1,7 +1,7 @@
 /* GPU Kernels.
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
- * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/gpu/kernels.hpp
+++ b/gpu/kernels.hpp
@@ -1,9 +1,9 @@
-/** GPU Kernels.
+/* GPU Kernels.
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -19,5 +19,5 @@ kernel_mailbox(volatile uint32_t *mailbox, volatile uint32_t* counter);
 __global__ void
 kernel_memcpy(volatile uint8_t* dst, volatile uint8_t* src, size_t length);
 
-} /* namespace villas */
-} /* namespace gpu */
+} // namespace villas
+} // namespace gpu

--- a/gpu/src/gpu.cpp
+++ b/gpu/src/gpu.cpp
@@ -1,9 +1,9 @@
-/** GPU managment.
+/* GPU managment.
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <cstdio>
 #include <cstdint>

--- a/gpu/src/gpu.cpp
+++ b/gpu/src/gpu.cpp
@@ -1,7 +1,7 @@
 /* GPU managment.
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
- * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/gpu/src/kernels.cu
+++ b/gpu/src/kernels.cu
@@ -1,7 +1,7 @@
 /** GPU Kernels.
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
- * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  *********************************************************************************/
 

--- a/include/villas/fpga/card.hpp
+++ b/include/villas/fpga/card.hpp
@@ -1,4 +1,4 @@
-/** FPGA card
+/* FPGA card
  *
  * This class represents a FPGA device.
  *
@@ -6,7 +6,8 @@
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
+
 #pragma once
 
 #include <set>
@@ -52,5 +53,5 @@ protected:
         Logger logger;
 };
 
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/card.hpp
+++ b/include/villas/fpga/card.hpp
@@ -4,7 +4,7 @@
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * Author: Daniel Krebs <github@daniel-krebs.net>
- * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/include/villas/fpga/config.h
+++ b/include/villas/fpga/config.h
@@ -1,4 +1,4 @@
-/** Compile time configuration
+/* Compile time configuration
  *
  * This file contains some compiled-in settings.
  * This settings are not part of the configuration file.
@@ -6,7 +6,7 @@
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -15,6 +15,6 @@
 #define FPGA_PCI_VID_XILINX	0x10ee
 #define FPGA_PCI_PID_VFPGA	0x7022
 
-/** AXI Bus frequency for all components
+/* AXI Bus frequency for all components
  * except RTDS AXI Stream bridge which runs at RTDS_HZ (100 Mhz) */
 #define FPGA_AXI_HZ		125000000 // 125 MHz

--- a/include/villas/fpga/config.h
+++ b/include/villas/fpga/config.h
@@ -4,7 +4,7 @@
  * This settings are not part of the configuration file.
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
- * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/include/villas/fpga/core.hpp
+++ b/include/villas/fpga/core.hpp
@@ -1,4 +1,4 @@
-/** Interlectual Property component.
+/* Interlectual Property component.
  *
  * This class represents a module within the FPGA.
  *
@@ -6,7 +6,7 @@
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -342,6 +342,6 @@ private:
 	};
 };
 
-} /* namespace ip */
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace ip
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/core.hpp
+++ b/include/villas/fpga/core.hpp
@@ -4,7 +4,7 @@
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * Author: Daniel Krebs <github@daniel-krebs.net>
- * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/include/villas/fpga/dma.h
+++ b/include/villas/fpga/dma.h
@@ -1,9 +1,9 @@
-/** C bindings for VILLASfpga
+/* C bindings for VILLASfpga
  *
  * Author: Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
  * SPDX-FileCopyrightText: 2023 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
  * SPDX-License-Identifier: Apache-2.0
- ******************************************************************************/
+ */
 
 #ifndef _VILLASFPGA_DMA_H
 #define _VILLASFPGA_DMA_H
@@ -36,4 +36,4 @@ int villasfpga_write_complete(villasfpga_handle handle, size_t *size);
 } // extern "C"
 #endif
 
-#endif /* _VILLASFPGA_DMA_H */
+#endif // _VILLASFPGA_DMA_H

--- a/include/villas/fpga/ips/aurora.hpp
+++ b/include/villas/fpga/ips/aurora.hpp
@@ -1,7 +1,7 @@
 /* Driver for wrapper around Aurora (acs.eonerc.rwth-aachen.de:user:aurora)
  *
  * Author: Hatim Kanchwala <hatim@hatimak.me>
- * SPDX-FileCopyrightText: 2020 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2020 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/include/villas/fpga/ips/aurora.hpp
+++ b/include/villas/fpga/ips/aurora.hpp
@@ -1,9 +1,9 @@
-/** Driver for wrapper around Aurora (acs.eonerc.rwth-aachen.de:user:aurora)
+/* Driver for wrapper around Aurora (acs.eonerc.rwth-aachen.de:user:aurora)
  *
  * Author: Hatim Kanchwala <hatim@hatimak.me>
  * SPDX-FileCopyrightText: 2020 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -50,6 +50,6 @@ private:
 	static constexpr const char registerMemory[] = "reg0";
 };
 
-} /* namespace ip */
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace ip
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/ips/aurora_xilinx.hpp
+++ b/include/villas/fpga/ips/aurora_xilinx.hpp
@@ -1,7 +1,7 @@
 /* Driver for wrapper around standard Xilinx Aurora (xilinx.com:ip:aurora_8b10b)
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
- * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/include/villas/fpga/ips/aurora_xilinx.hpp
+++ b/include/villas/fpga/ips/aurora_xilinx.hpp
@@ -1,9 +1,9 @@
-/** Driver for wrapper around standard Xilinx Aurora (xilinx.com:ip:aurora_8b10b)
+/* Driver for wrapper around standard Xilinx Aurora (xilinx.com:ip:aurora_8b10b)
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -31,6 +31,6 @@ public:
 	}
 };
 
-} /* namespace ip */
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace ip
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/ips/bram.hpp
+++ b/include/villas/fpga/ips/bram.hpp
@@ -1,9 +1,9 @@
-/** Block-Raam related helper functions
+/* Block-Raam related helper functions
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2018 Daniel Krebs <github@daniel-krebs.net>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -77,6 +77,6 @@ protected:
 	void parse(Core &, json_t *) override;
 };
 
-} /* namespace ip */
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace ip
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/ips/dino.hpp
+++ b/include/villas/fpga/ips/dino.hpp
@@ -1,7 +1,7 @@
 /* Driver for wrapper around Dino
  *
  * Author: Steffen Vogel <svogel2@eonerc.rwth-aachen.de>
- * SPDX-FileCopyrightText: 2020 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2020 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/include/villas/fpga/ips/dino.hpp
+++ b/include/villas/fpga/ips/dino.hpp
@@ -1,9 +1,9 @@
-/** Driver for wrapper around Dino
+/* Driver for wrapper around Dino
  *
  * Author: Steffen Vogel <svogel2@eonerc.rwth-aachen.de>
  * SPDX-FileCopyrightText: 2020 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -29,6 +29,6 @@ public:
 	}
 };
 
-} /* namespace ip */
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace ip
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/ips/dma.hpp
+++ b/include/villas/fpga/ips/dma.hpp
@@ -3,7 +3,7 @@
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * Author: Steffen Vogel <post@steffenvogel.de>
  * Author: Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
- * SPDX-FileCopyrightText: 2018 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2018 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/include/villas/fpga/ips/dma.hpp
+++ b/include/villas/fpga/ips/dma.hpp
@@ -1,11 +1,11 @@
-/** DMA driver
+/* DMA driver
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * Author: Steffen Vogel <post@steffenvogel.de>
  * Author: Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
  * SPDX-FileCopyrightText: 2018 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- ******************************************************************************/
+ */
 
 #pragma once
 
@@ -183,6 +183,6 @@ protected:
 	}
 };
 
-} /* namespace ip */
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace ip
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/ips/emc.hpp
+++ b/include/villas/fpga/ips/emc.hpp
@@ -1,9 +1,9 @@
-/** AXI External Memory Controller (EMC)
+/* AXI External Memory Controller (EMC)
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -40,6 +40,6 @@ private:
 	}
 };
 
-} /* namespace ip */
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace ip
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/ips/fifo.hpp
+++ b/include/villas/fpga/ips/fifo.hpp
@@ -1,4 +1,4 @@
-/** Timer related helper functions
+/* Timer related helper functions
  *
  * These functions present a simpler interface to Xilinx' Timer Counter driver (XTmrCtr_*)
  *
@@ -6,7 +6,7 @@
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 
 #pragma once
@@ -52,6 +52,6 @@ class FifoData : public Node {
 	friend class FifoDataFactory;
 };
 
-} /* namespace ip */
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace ip
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/ips/gpio.hpp
+++ b/include/villas/fpga/ips/gpio.hpp
@@ -1,10 +1,10 @@
-/** AXI General Purpose IO (GPIO)
+/* AXI General Purpose IO (GPIO)
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -32,6 +32,6 @@ private:
 	}
 };
 
-} /* namespace ip */
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace ip
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/ips/gpu2rtds.hpp
+++ b/include/villas/fpga/ips/gpu2rtds.hpp
@@ -1,9 +1,9 @@
-/** GPU2RTDS IP core
+/* GPU2RTDS IP core
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Daniel Krebs <github@daniel-krebs.net>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -73,6 +73,6 @@ public:
 	bool started;
 };
 
-} /* namespace ip */
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace ip
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/ips/hls.hpp
+++ b/include/villas/fpga/ips/hls.hpp
@@ -1,9 +1,9 @@
-/** HLS IP core
+/* HLS IP core
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -157,6 +157,6 @@ protected:
 	bool running;
 };
 
-} /* namespace ip */
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace ip
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/ips/intc.hpp
+++ b/include/villas/fpga/ips/intc.hpp
@@ -1,10 +1,10 @@
-/** AXI-PCIe Interrupt controller
+/* AXI-PCIe Interrupt controller
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -68,6 +68,6 @@ private:
 	bool polling[maxIrqs];
 };
 
-} /* namespace ip */
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace ip
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/ips/pcie.hpp
+++ b/include/villas/fpga/ips/pcie.hpp
@@ -1,4 +1,4 @@
-/** AXI Stream interconnect related helper functions
+/* AXI Stream interconnect related helper functions
  *
  * These functions present a simpler interface to Xilinx' AXI Stream switch driver (XAxis_Switch_*)
  *
@@ -6,7 +6,7 @@
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -76,6 +76,6 @@ protected:
 	void parse(Core &, json_t *) override;
 };
 
-} /* namespace ip */
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace ip
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/ips/rtds.hpp
+++ b/include/villas/fpga/ips/rtds.hpp
@@ -1,9 +1,9 @@
-/** Driver for AXI Stream wrapper around RTDS_InterfaceModule (rtds_axis )
+/* Driver for AXI Stream wrapper around RTDS_InterfaceModule (rtds_axis )
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -49,6 +49,6 @@ private:
 	static constexpr const char* irqCase = "irq_case";
 };
 
-} /* namespace ip */
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace ip
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/ips/rtds2gpu.hpp
+++ b/include/villas/fpga/ips/rtds2gpu.hpp
@@ -1,9 +1,9 @@
-/** GPU2RTDS IP core
+/* GPU2RTDS IP core
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Daniel Krebs <github@daniel-krebs.net>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -91,6 +91,6 @@ private:
 	bool started;
 };
 
-} /* namespace ip */
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace ip
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/ips/rtds2gpu/register_types.hpp
+++ b/include/villas/fpga/ips/rtds2gpu/register_types.hpp
@@ -1,9 +1,9 @@
-/** GPU2RTDS register types
+/* GPU2RTDS register types
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Daniel Krebs <github@daniel-krebs.net>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 

--- a/include/villas/fpga/ips/switch.hpp
+++ b/include/villas/fpga/ips/switch.hpp
@@ -1,4 +1,4 @@
-/** AXI Stream interconnect related helper functions
+/* AXI Stream interconnect related helper functions
  *
  * These functions present a simpler interface to Xilinx' AXI Stream switch driver (XAxis_Switch_*)
  *
@@ -6,7 +6,7 @@
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -86,6 +86,6 @@ protected:
 	void parse(Core &, json_t *) override;
 };
 
-} /* namespace ip */
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace ip
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/ips/timer.hpp
+++ b/include/villas/fpga/ips/timer.hpp
@@ -1,4 +1,4 @@
-/** Timer related helper functions
+/* Timer related helper functions
  *
  * These functions present a simpler interface to Xilinx' Timer Counter driver (XTmrCtr_*)
  *
@@ -6,7 +6,7 @@
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -64,6 +64,6 @@ private:
 	XTmrCtr xTmr;
 };
 
-} /* namespace ip */
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace ip
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/node.hpp
+++ b/include/villas/fpga/node.hpp
@@ -1,4 +1,4 @@
-/** Interlectual Property component.
+/* Interlectual Property component.
  *
  * This class represents a module within the FPGA.
  *
@@ -6,7 +6,7 @@
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -182,6 +182,6 @@ private:
 	}
 };
 
-} /* namespace ip */
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace ip
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/node.hpp
+++ b/include/villas/fpga/node.hpp
@@ -4,7 +4,7 @@
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * Author: Daniel Krebs <github@daniel-krebs.net>
- * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/include/villas/fpga/pcie_card.hpp
+++ b/include/villas/fpga/pcie_card.hpp
@@ -4,7 +4,7 @@
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * Author: Daniel Krebs <github@daniel-krebs.net>
- * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/include/villas/fpga/pcie_card.hpp
+++ b/include/villas/fpga/pcie_card.hpp
@@ -1,4 +1,4 @@
-/** FPGA pciecard
+/* FPGA pciecard
  *
  * This class represents a FPGA device.
  *
@@ -6,7 +6,7 @@
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -115,5 +115,5 @@ public:
 	}
 };
 
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/utils.hpp
+++ b/include/villas/fpga/utils.hpp
@@ -1,8 +1,8 @@
-/** Helper function for directly using VILLASfpga outside of VILLASnode
+/* Helper function for directly using VILLASfpga outside of VILLASnode
  * Author: Niklas Eiling <niklas.eiling@rwth-aachen.de>
  * SPDX-FileCopyrightText: 2022 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -122,5 +122,5 @@ protected:
 
 std::unique_ptr<BufferedSampleFormatter> getBufferedSampleFormatter(const std::string &format, size_t bufSizeInSamples);
 
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/utils.hpp
+++ b/include/villas/fpga/utils.hpp
@@ -1,6 +1,6 @@
 /* Helper function for directly using VILLASfpga outside of VILLASnode
  * Author: Niklas Eiling <niklas.eiling@rwth-aachen.de>
- * SPDX-FileCopyrightText: 2022 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
+ * SPDX-FileCopyrightText: 2022-2023 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/include/villas/fpga/vlnv.hpp
+++ b/include/villas/fpga/vlnv.hpp
@@ -1,9 +1,9 @@
-/** Vendor, Library, Name, Version (VLNV) tag.
+/* Vendor, Library, Name, Version (VLNV) tag.
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 
@@ -68,5 +68,5 @@ private:
 	std::string version;
 };
 
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace fpga
+} // namespace villas

--- a/include/villas/fpga/vlnv.hpp
+++ b/include/villas/fpga/vlnv.hpp
@@ -1,7 +1,7 @@
 /* Vendor, Library, Name, Version (VLNV) tag.
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
- * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,9 +1,8 @@
 ## CMakeLists.txt
 #
 # Author: Daniel Krebs <github@daniel-krebs.net>
-# SPDX-FileCopyrightText: 2018 Institute for Automation of Complex Power Systems, EONERC
+# SPDX-FileCopyrightText: 2018 Institute for Automation of Complex Power Systems, RWTH Aachen University
 # SPDX-License-Identifier: Apache-2.0
-##############################################################################
 
 set(SOURCES
 	vlnv.cpp

--- a/lib/card.cpp
+++ b/lib/card.cpp
@@ -4,8 +4,8 @@
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * Author: Daniel Krebs <github@daniel-krebs.net>
- * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power
- * Systems, EONERC SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <villas/fpga/card.hpp>

--- a/lib/card.cpp
+++ b/lib/card.cpp
@@ -1,4 +1,4 @@
-/** FPGA card
+/* FPGA card
  *
  * This class represents a FPGA device.
  *
@@ -6,7 +6,7 @@
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power
  * Systems, EONERC SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <villas/fpga/card.hpp>
 

--- a/lib/core.cpp
+++ b/lib/core.cpp
@@ -1,9 +1,9 @@
-/** FPGA IP component.
+/* FPGA IP component.
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <string>
 #include <memory>

--- a/lib/core.cpp
+++ b/lib/core.cpp
@@ -1,7 +1,7 @@
 /* FPGA IP component.
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
- * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/dma.cpp
+++ b/lib/dma.cpp
@@ -1,9 +1,9 @@
-/** API for interacting with the FPGA DMA Controller.
+/* API for interacting with the FPGA DMA Controller.
  *
  * Author: Niklas Eiling <niklas.eiling@rwth-aachen.de>
  * SPDX-FileCopyrightText: 2023 Niklas Eiling <niklas.eiling@rwth-aachen.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <villas/fpga/dma.h>
 

--- a/lib/ips/aurora.cpp
+++ b/lib/ips/aurora.cpp
@@ -1,7 +1,7 @@
 /* Driver for wrapper around Aurora (acs.eonerc.rwth-aachen.de:user:aurora)
  *
  * Author: Hatim Kanchwala <hatim@hatimak.me>
- * SPDX-FileCopyrightText: 2020 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2020 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/ips/aurora.cpp
+++ b/lib/ips/aurora.cpp
@@ -1,9 +1,9 @@
-/** Driver for wrapper around Aurora (acs.eonerc.rwth-aachen.de:user:aurora)
+/* Driver for wrapper around Aurora (acs.eonerc.rwth-aachen.de:user:aurora)
  *
  * Author: Hatim Kanchwala <hatim@hatimak.me>
  * SPDX-FileCopyrightText: 2020 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <cstdint>
 
@@ -37,12 +37,12 @@
 // Sequence number must be handled in software then.
 #define AURORA_AXIS_CR_SEQ_MODE			(1 << 2)
 
-/** 1-bit, assert to strip the received frame of the trailing sequence
+/* 1-bit, assert to strip the received frame of the trailing sequence
  * number. Sequence number mode must be set to handled by Aurora IP,
  * otherwise this bit is ignored. */
 #define AURORA_AXIS_CR_SEQ_STRIP		(1 << 3)
 
-/** 1-bit, assert to use the same sequence number in the outgoing
+/* 1-bit, assert to use the same sequence number in the outgoing
  * NovaCor-bound frames as the sequence number received from the
  * incoming frames from NovaCor. Sequence number mode must be set to
  * handled by Aurora IP, otherwise this bit is ignored.*/

--- a/lib/ips/aurora_xilinx.cpp
+++ b/lib/ips/aurora_xilinx.cpp
@@ -1,7 +1,7 @@
 /* Driver for wrapper around standard Xilinx Aurora (xilinx.com:ip:aurora_8b10b)
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
- * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/ips/aurora_xilinx.cpp
+++ b/lib/ips/aurora_xilinx.cpp
@@ -1,9 +1,9 @@
-/** Driver for wrapper around standard Xilinx Aurora (xilinx.com:ip:aurora_8b10b)
+/* Driver for wrapper around standard Xilinx Aurora (xilinx.com:ip:aurora_8b10b)
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <cstdint>
 

--- a/lib/ips/bram.cpp
+++ b/lib/ips/bram.cpp
@@ -1,9 +1,9 @@
-/** Block RAM IP.
+/* Block RAM IP.
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <villas/exceptions.hpp>
 #include <villas/fpga/ips/bram.hpp>

--- a/lib/ips/bram.cpp
+++ b/lib/ips/bram.cpp
@@ -1,7 +1,7 @@
 /* Block RAM IP.
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
- * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/ips/dino.cpp
+++ b/lib/ips/dino.cpp
@@ -1,7 +1,7 @@
 /* Driver for wrapper around standard Xilinx Aurora (xilinx.com:ip:aurora_8b10b)
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
- * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/ips/dino.cpp
+++ b/lib/ips/dino.cpp
@@ -1,9 +1,9 @@
-/** Driver for wrapper around standard Xilinx Aurora (xilinx.com:ip:aurora_8b10b)
+/* Driver for wrapper around standard Xilinx Aurora (xilinx.com:ip:aurora_8b10b)
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <cstdint>
 

--- a/lib/ips/dma.cpp
+++ b/lib/ips/dma.cpp
@@ -1,10 +1,10 @@
-/** DMA driver
+/* DMA driver
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * Author: Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
  * SPDX-FileCopyrightText: 2018 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- ******************************************************************************/
+ */
 
 #include <sstream>
 #include <string>

--- a/lib/ips/dma.cpp
+++ b/lib/ips/dma.cpp
@@ -2,7 +2,7 @@
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * Author: Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
- * SPDX-FileCopyrightText: 2018 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2018 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/ips/emc.cpp
+++ b/lib/ips/emc.cpp
@@ -1,9 +1,9 @@
-/** AXI External Memory Controller (EMC)
+/* AXI External Memory Controller (EMC)
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <iostream>
 
@@ -42,7 +42,7 @@ bool EMC::read(uint32_t offset, uint32_t length, uint8_t *data)
 {
 	int ret;
 
-	/** Reset the Flash Device. This clears the ret registers and puts
+	/* Reset the Flash Device. This clears the ret registers and puts
 	 * the device in Read mode.
 	 */
 	ret = XFlash_Reset(&xflash);

--- a/lib/ips/fifo.cpp
+++ b/lib/ips/fifo.cpp
@@ -1,4 +1,4 @@
-/** FIFO related helper functions
+/* FIFO related helper functions
  *
  * These functions present a simpler interface to Xilinx' FIFO driver (XLlFifo_*)
  *
@@ -6,7 +6,7 @@
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <unistd.h>
 

--- a/lib/ips/gpio.cpp
+++ b/lib/ips/gpio.cpp
@@ -1,9 +1,9 @@
-/** AXI General Purpose IO (GPIO)
+/* AXI General Purpose IO (GPIO)
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <villas/plugin.hpp>
 

--- a/lib/ips/intc.cpp
+++ b/lib/ips/intc.cpp
@@ -1,9 +1,9 @@
-/** AXI-PCIe Interrupt controller
+/* AXI-PCIe Interrupt controller
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <unistd.h>
 #include <errno.h>

--- a/lib/ips/pcie.cpp
+++ b/lib/ips/pcie.cpp
@@ -1,9 +1,9 @@
-/** AXI PCIe bridge
+/* AXI PCIe bridge
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2018 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <limits>
 #include <jansson.h>

--- a/lib/ips/pcie.cpp
+++ b/lib/ips/pcie.cpp
@@ -1,7 +1,7 @@
 /* AXI PCIe bridge
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
- * SPDX-FileCopyrightText: 2018 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2018 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/ips/rtds.cpp
+++ b/lib/ips/rtds.cpp
@@ -1,9 +1,9 @@
-/** Driver for AXI Stream wrapper around RTDS_InterfaceModule (rtds_axis )
+/* Driver for AXI Stream wrapper around RTDS_InterfaceModule (rtds_axis )
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <cstdint>
 

--- a/lib/ips/rtds2gpu/gpu2rtds.cpp
+++ b/lib/ips/rtds2gpu/gpu2rtds.cpp
@@ -1,9 +1,9 @@
-/** GPU2RTDS IP core
+/* GPU2RTDS IP core
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Daniel Krebs <github@daniel-krebs.net>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <unistd.h>
 #include <cstring>

--- a/lib/ips/rtds2gpu/rtds2gpu.cpp
+++ b/lib/ips/rtds2gpu/rtds2gpu.cpp
@@ -1,9 +1,9 @@
-/** GPU2RTDS IP core
+/* GPU2RTDS IP core
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Daniel Krebs <github@daniel-krebs.net>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <unistd.h>
 #include <cstring>

--- a/lib/ips/switch.cpp
+++ b/lib/ips/switch.cpp
@@ -1,4 +1,4 @@
-/** AXI Stream interconnect related helper functions
+/* AXI Stream interconnect related helper functions
  *
  * These functions present a simpler interface to Xilinx' AXI Stream switch driver (XAxis_Switch_*)
  *
@@ -6,7 +6,7 @@
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <jansson.h>
 #include <xilinx/xaxis_switch.h>
@@ -135,6 +135,6 @@ void AxiStreamSwitchFactory::parse(Core &ip, json_t *cfg)
 
 static AxiStreamSwitchFactory f;
 
-} /* namespace ip */
-} /* namespace fpga */
-} /* namespace villas */
+} // namespace ip
+} // namespace fpga
+} // namespace villas

--- a/lib/ips/timer.cpp
+++ b/lib/ips/timer.cpp
@@ -1,4 +1,4 @@
-/** Timer related helper functions
+/* Timer related helper functions
  *
  * These functions present a simpler interface to Xilinx' Timer Counter driver (XTmrCtr_*)
  *
@@ -6,7 +6,7 @@
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <cstdint>
 

--- a/lib/memory.cpp
+++ b/lib/memory.cpp
@@ -1,9 +1,9 @@
-/** Memory managment.
+/* Memory managment.
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <sys/mman.h>
 #include <unistd.h>

--- a/lib/memory.cpp
+++ b/lib/memory.cpp
@@ -1,7 +1,7 @@
 /* Memory managment.
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
- * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/node.cpp
+++ b/lib/node.cpp
@@ -1,7 +1,7 @@
 /* An IP node.
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
- * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/node.cpp
+++ b/lib/node.cpp
@@ -1,9 +1,9 @@
-/** An IP node.
+/* An IP node.
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <map>
 #include <stdexcept>

--- a/lib/pcie_card.cpp
+++ b/lib/pcie_card.cpp
@@ -1,9 +1,9 @@
-/** FPGA pciecard.
+/* FPGA pciecard.
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <string>
 #include <memory>

--- a/lib/pcie_card.cpp
+++ b/lib/pcie_card.cpp
@@ -1,7 +1,7 @@
 /* FPGA pciecard.
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
- * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/utils.cpp
+++ b/lib/utils.cpp
@@ -1,10 +1,10 @@
-/** Helper function for directly using VILLASfpga outside of VILLASnode
+/* Helper function for directly using VILLASfpga outside of VILLASnode
  *
  * Author: Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
  * SPDX-FileCopyrightText: 2022 Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2022 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <csignal>
 #include <iostream>

--- a/lib/utils.cpp
+++ b/lib/utils.cpp
@@ -1,8 +1,8 @@
 /* Helper function for directly using VILLASfpga outside of VILLASnode
  *
  * Author: Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
- * SPDX-FileCopyrightText: 2022 Steffen Vogel <post@steffenvogel.de>
- * SPDX-FileCopyrightText: 2022 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
+ * SPDX-FileCopyrightText: 2022-2023 Steffen Vogel <post@steffenvogel.de>
+ * SPDX-FileCopyrightText: 2022-2023 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/vlnv.cpp
+++ b/lib/vlnv.cpp
@@ -1,7 +1,7 @@
 /* Vendor, Library, Name, Version (VLNV) tag
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
- * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/vlnv.cpp
+++ b/lib/vlnv.cpp
@@ -1,9 +1,9 @@
-/** Vendor, Library, Name, Version (VLNV) tag
+/* Vendor, Library, Name, Version (VLNV) tag
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <string>
 #include <sstream>

--- a/libvillas-fpga.pc.in
+++ b/libvillas-fpga.pc.in
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
 # SPDX-License-Identifier: Apache-2.0
 
 prefix=@CMAKE_INSTALL_PREFIX@

--- a/past-commits.txt
+++ b/past-commits.txt
@@ -1,4 +1,4 @@
-SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
 SPDX-License-Identifier: Apache-2.0
 
 I, Niklas Eiling hereby sign-off-by all of my past commits to this repo subject to the Developer Certificate of Origin (DCO), Version 1.1. In the past I have used emails: niklas.eiling@eonerc.rwth-aachen.de

--- a/scripts/gdb_sudo.sh
+++ b/scripts/gdb_sudo.sh
@@ -4,8 +4,7 @@
 # See: .vscode directory
 #
 # Author: Steffen Vogel <post@steffenvogel.de>
-# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
 
 sudo pkexec /usr/bin/gdb "$@"

--- a/scripts/non_root.sh
+++ b/scripts/non_root.sh
@@ -3,9 +3,8 @@
 # Setup VFIO for non-root users
 #
 # Author: Steffen Vogel <post@steffenvogel.de>
-# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
 
 # PCI-e parameters of FPGA card
 PCI_BDF="0000:03:00.0"

--- a/scripts/rebind_device.sh
+++ b/scripts/rebind_device.sh
@@ -3,9 +3,8 @@
 # Detach and rebind a PCI device to a PCI kernel driver
 #
 # Author: Steffen Vogel <post@steffenvogel.de>
-# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
 
 if [ "$#" -ne 2 ]; then
 	echo "usage: $0 BUS:DEV:FNC DRIVER"

--- a/scripts/reset_pci_device.sh
+++ b/scripts/reset_pci_device.sh
@@ -3,9 +3,8 @@
 # Reset PCI devices like FPGAs after a reflash
 #
 # Author: Steffen Vogel <post@steffenvogel.de>
-# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, EONERC
+# SPDX-FileCopyrightText: 2017 Institute for Automation of Complex Power Systems, RWTH Aachen University
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
 
 if [ "$#" -ne 1 ]; then
         echo "usage: $0 BUS:DEV.FNC"

--- a/scripts/villas-fpga-cat.sh
+++ b/scripts/villas-fpga-cat.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 # 
 # Author: Niklas Eiling <niklas.eiling@rwth-aachen.de>
-# SPDX-FileCopyrightText: 2023 Institute for Automation of Complex Power Systems, EONERC
+# SPDX-FileCopyrightText: 2023 Institute for Automation of Complex Power Systems, RWTH Aachen University
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
 
 CWD=$(dirname -- "$0")
 

--- a/scripts/villas-fpga-xbar-select.sh
+++ b/scripts/villas-fpga-xbar-select.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 # 
 # Author: Niklas Eiling <niklas.eiling@rwth-aachen.de>
-# SPDX-FileCopyrightText: 2023 Institute for Automation of Complex Power Systems, EONERC
+# SPDX-FileCopyrightText: 2023 Institute for Automation of Complex Power Systems, RWTH Aachen University
 # SPDX-License-Identifier: Apache-2.0
-##################################################################################
 
 CWD=$(dirname -- "$0")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,8 @@
 ## CMakeLists.txt
 #
 # Author: Daniel Krebs <github@daniel-krebs.net>
-# SPDX-FileCopyrightText: 2018 Institute for Automation of Complex Power Systems, EONERC
+# SPDX-FileCopyrightText: 2018 Institute for Automation of Complex Power Systems, RWTH Aachen University
 # SPDX-License-Identifier: Apache-2.0
-##############################################################################
 
 add_executable(villas-fpga-ctrl villas-fpga-ctrl.cpp)
 

--- a/src/README.pcimem.md
+++ b/src/README.pcimem.md
@@ -1,9 +1,11 @@
 # pcimem tool
 
-SPDX-FileCopyrightText: 2010 Bill Farrow <bfarrow@beyondelectronics.us>
-SPDX-FileCopyrightText: 2022 Institute for Automation of Complex Power Systems, EONERC
-SPDX-FileCopyrightText: 2000 Jan-Derk Bakker <J.D.Bakker@its.tudelft.nl>
-SPDX-License-Identifier: GPL-2.0-or-later
+## License
+
+- SPDX-FileCopyrightText: 2010 Bill Farrow <bfarrow@beyondelectronics.us>
+- SPDX-FileCopyrightText: 2023 Institute for Automation of Complex Power Systems, RWTH Aachen University
+- SPDX-FileCopyrightText: 2000 Jan-Derk Bakker <J.D.Bakker@its.tudelft.nl>
+- SPDX-License-Identifier: GPL-2.0-or-later
 
 ## Overview
 

--- a/src/pcimem.c
+++ b/src/pcimem.c
@@ -1,4 +1,4 @@
-/** Simple program to read/write from/to a pci device from userspace.
+/* Simple program to read/write from/to a pci device from userspace.
  *
  * SPDX-FileCopyrightText: 2010 Bill Farrow <bfarrow@beyondelectronics.us>
  * SPDX-FileCopyrightText: 2022 Institute for Automation of Complex Power Systems, EONERC
@@ -6,7 +6,7 @@
  *  Based on the devmem2.c code
  * SPDX-FileCopyrightText: 2000 Jan-Derk Bakker <J.D.Bakker@its.tudelft.nl>
  * SPDX-License-Identifier: GPL-2.0-or-later
- *********************************************************************************/
+ */
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/pcimem.c
+++ b/src/pcimem.c
@@ -1,9 +1,10 @@
 /* Simple program to read/write from/to a pci device from userspace.
  *
  * SPDX-FileCopyrightText: 2010 Bill Farrow <bfarrow@beyondelectronics.us>
- * SPDX-FileCopyrightText: 2022 Institute for Automation of Complex Power Systems, EONERC
+ * SPDX-FileCopyrightText: 2023 Institute for Automation of Complex Power Systems, RWTH Aachen University
  *
  *  Based on the devmem2.c code
+ *
  * SPDX-FileCopyrightText: 2000 Jan-Derk Bakker <J.D.Bakker@its.tudelft.nl>
  * SPDX-License-Identifier: GPL-2.0-or-later
  */

--- a/src/villas-fpga-ctrl.cpp
+++ b/src/villas-fpga-ctrl.cpp
@@ -3,7 +3,7 @@
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * Author: Niklas Eiling <niklas.eiling@rwth-aachen.de>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
- * SPDX-FileCopyrightText: 2022 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
+ * SPDX-FileCopyrightText: 2022-2023 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/src/villas-fpga-ctrl.cpp
+++ b/src/villas-fpga-ctrl.cpp
@@ -1,11 +1,11 @@
-/** Streaming data from STDIN/OUT to FPGA.
+/* Streaming data from STDIN/OUT to FPGA.
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * Author: Niklas Eiling <niklas.eiling@rwth-aachen.de>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2022 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <csignal>
 #include <iostream>

--- a/src/villas-fpga-pipe.cpp
+++ b/src/villas-fpga-pipe.cpp
@@ -1,9 +1,9 @@
-/** Streaming data from STDIN/OUT to FPGA.
+/* Streaming data from STDIN/OUT to FPGA.
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <csignal>
 #include <iostream>

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,9 +1,8 @@
 ## CMakeLists.txt
 #
 # Author: Daniel Krebs <github@daniel-krebs.net>
-# SPDX-FileCopyrightText: 2018 Institute for Automation of Complex Power Systems, EONERC
+# SPDX-FileCopyrightText: 2018 Institute for Automation of Complex Power Systems, RWTH Aachen University
 # SPDX-License-Identifier: Apache-2.0
-##############################################################################
 
 set(SOURCES
 	dma.cpp

--- a/tests/unit/dma.c
+++ b/tests/unit/dma.c
@@ -1,9 +1,9 @@
-/** Testing the C bindings for the VILLASfpga DMA interface.
+/* Testing the C bindings for the VILLASfpga DMA interface.
  *
  * Author: Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
  * SPDX-FileCopyrightText: 2023 Niklas Eiling <niklas.eiling@eonerc.rwth-aachen.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/tests/unit/dma.cpp
+++ b/tests/unit/dma.cpp
@@ -1,9 +1,9 @@
-/** DMA unit test.
+/* DMA unit test.
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <criterion/criterion.h>
 

--- a/tests/unit/fifo.cpp
+++ b/tests/unit/fifo.cpp
@@ -1,9 +1,9 @@
-/** FIFO unit test.
+/* FIFO unit test.
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <criterion/criterion.h>
 

--- a/tests/unit/fpga.cpp
+++ b/tests/unit/fpga.cpp
@@ -1,9 +1,9 @@
-/** FPGA related code for bootstrapping the unit-tests
+/* FPGA related code for bootstrapping the unit-tests
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2018 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <criterion/criterion.h>
 

--- a/tests/unit/global.hpp
+++ b/tests/unit/global.hpp
@@ -1,9 +1,9 @@
-/** Global include for tests.
+/* Global include for tests.
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #pragma once
 

--- a/tests/unit/gpu.cpp
+++ b/tests/unit/gpu.cpp
@@ -1,9 +1,9 @@
-/** GPU unit tests.
+/* GPU unit tests.
  *
 * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Daniel Krebs <github@daniel-krebs.net>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <criterion/criterion.h>
 

--- a/tests/unit/logging.cpp
+++ b/tests/unit/logging.cpp
@@ -1,9 +1,9 @@
-/** Logging utilities for unit test.
+/* Logging utilities for unit test.
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <cstdarg>
 #include <memory>

--- a/tests/unit/main.cpp
+++ b/tests/unit/main.cpp
@@ -1,9 +1,9 @@
-/** Main Unit Test entry point.
+/* Main Unit Test entry point.
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <criterion/criterion.h>
 #include <criterion/options.h>

--- a/tests/unit/rtds.cpp
+++ b/tests/unit/rtds.cpp
@@ -1,11 +1,11 @@
-/** RTDS AXI-Stream RTT unit test.
+/* RTDS AXI-Stream RTT unit test.
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2018 Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2018 Daniel Krebs <github@daniel-krebs.net>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <list>
 

--- a/tests/unit/rtds2gpu.cpp
+++ b/tests/unit/rtds2gpu.cpp
@@ -1,9 +1,9 @@
-/** FIFO unit test.
+/* FIFO unit test.
  *
  * Author: Daniel Krebs <github@daniel-krebs.net>
  * SPDX-FileCopyrightText: 2017 Daniel Krebs <github@daniel-krebs.net>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <criterion/criterion.h>
 

--- a/tests/unit/rtds_rtt.cpp
+++ b/tests/unit/rtds_rtt.cpp
@@ -1,9 +1,9 @@
-/** RTDS AXI-Stream RTT unit test.
+/* RTDS AXI-Stream RTT unit test.
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <criterion/criterion.h>
 

--- a/tests/unit/timer.cpp
+++ b/tests/unit/timer.cpp
@@ -1,9 +1,9 @@
-/** Timer/Counter unit test.
+/* Timer/Counter unit test.
  *
  * Author: Steffen Vogel <post@steffenvogel.de>
  * SPDX-FileCopyrightText: 2017 Steffen Vogel <post@steffenvogel.de>
  * SPDX-License-Identifier: Apache-2.0
- *********************************************************************************/
+ */
 
 #include <chrono>
 #include <criterion/criterion.h>


### PR DESCRIPTION
This edits the headers in every file so the copyright notice mentions RWTH Aachen University. We also update some copyright years and fix various comments so the header is the same across all of VILLASframework.